### PR TITLE
Submit driver control tweaks and telemetry updates from robot testing today

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DirectControl.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DirectControl.java
@@ -25,8 +25,11 @@ public class DirectControl extends LinearOpMode {
 
     waitForStart();
     ElapsedTime sinceLastUsedGrabRotate = new ElapsedTime();
-    while (opModeIsActive()) {
+    ElapsedTime timeSinceStart = new ElapsedTime();
+    ElapsedTime loopTime = new ElapsedTime();
 
+    while (opModeIsActive()) {
+      loopTime.reset();
       // Handle Grabber rotation
       /*if (control.buttonA() == Button.Pressed) {
         if (robot.getGrabberPosition() == GrabberPosition.Vertical) {
@@ -102,6 +105,8 @@ public class DirectControl extends LinearOpMode {
       telemetry.addData("Right trigger pos: ", driver.rtrigger());
       // This is just steering
       manualCtrl.Steer();
+
+      telemetry.addLine(String.format("Timing: %.1f, %.1f", timeSinceStart.seconds(), loopTime.seconds()));
       telemetry.update();
     }
   }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DirectControl.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/DirectControl.java
@@ -24,7 +24,7 @@ public class DirectControl extends LinearOpMode {
     manualCtrl = new XDriveManualControl(robot, driver, control, telemetry);
 
     waitForStart();
-    ElapsedTime sinceLastUsed = new ElapsedTime();
+    ElapsedTime sinceLastUsedGrabRotate = new ElapsedTime();
     while (opModeIsActive()) {
 
       // Handle Grabber rotation
@@ -39,18 +39,22 @@ public class DirectControl extends LinearOpMode {
       if (control.rtrigger() > robot.TRIGGERTHRESHOLD) {
         robot.setClawPosition(ClawPosition.Open); // Open
       } else if (control.ltrigger() > robot.TRIGGERTHRESHOLD) {
-        robot.setClawPosition(ClawPosition.Close); // CLosed
+        robot.setClawPosition(ClawPosition.Close); // Closed
       }
       // Grabber rotation
-      if (control.lbump() == Button.Pressed && sinceLastUsed.seconds() > 0.5) {
-        robot.rotateClaw(false);
-        telemetry.addLine("Open 0.4");
-        sinceLastUsed.reset();
-      } else if (control.rbump() == Button.Pressed && sinceLastUsed.seconds() > 0.5) {
-        robot.rotateClaw(true);
-        telemetry.addLine("Close 0.6");
-        sinceLastUsed.reset();
+      final double grabRotationDebounceSecs = 0.25;
+      if (sinceLastUsedGrabRotate.seconds() > grabRotationDebounceSecs) {
+        if (control.lbump() == Button.Pressed) {
+          robot.rotateClaw(true);
+          telemetry.addLine("rotateClaw true");
+          sinceLastUsedGrabRotate.reset();
+        } else if (control.rbump() == Button.Pressed) {
+          robot.rotateClaw(false);
+          telemetry.addLine("rotateClaw false");
+          sinceLastUsedGrabRotate.reset();
+        }
       }
+
 
 
       // Override the linear slide limit switches

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TTRobot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TTRobot.java
@@ -103,6 +103,8 @@ public class TTRobot implements IRobot {
 
   // This is an 'opMode aware' sleep: It will stop if you hit 'stop'!
   public final void sleep(long milliseconds) {
+    telemetry.addData("Sleeping!", milliseconds);
+
     try {
       if (UNTESTED) {
         ElapsedTime tm = new ElapsedTime();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/XDriveManualControl.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/XDriveManualControl.java
@@ -28,14 +28,11 @@ public class XDriveManualControl {
     // Driver control:
     Direction Dpad = driver.dpad();
     Direction L = driver.lstick();
-    Direction R1 = driver.rstick();
-    Direction R2 = control.rstick();
+    Direction R = driver.rstick();
     Direction D = new Direction(0, 0);
     Direction L2 = new Direction(0, 0);
-    if (Math.abs(R2.X) > robot.STICK_DEAD_ZONE) {
-      D.X = R2.X;
-    } else if (Math.abs(R1.X) > robot.STICK_DEAD_ZONE) {
-      D.X = R1.X;
+    if (Math.abs(R.X) > robot.STICK_DEAD_ZONE) {
+      D.X = R.X;
     }
     if (Math.abs(L.X) > robot.STICK_DEAD_ZONE) {
       L2.X = L.X;
@@ -45,9 +42,7 @@ public class XDriveManualControl {
     }
 
     // Turbo Mode (insert Tristan happy face)
-    if ((control.rtrigger() == 1.0 || control.ltrigger() == 1.0)) {
-      robot.speedSnail();
-    } else if ((driver.rtrigger() == 1.0 || driver.ltrigger() == 1.0)) {
+    if ((driver.rtrigger() == 1.0 || driver.ltrigger() == 1.0)) {
       robot.speedTurbo();
     } else {
       robot.speedNormal();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/testcode/TestMotor.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/testcode/TestMotor.java
@@ -37,8 +37,8 @@ public class TestMotor extends LinearOpMode {
     // step (using the FTC Robot Controller app on the phone).
 
     motor = hardwareMap.get(DcMotor.class, "Mother");
-    encoder = "Mother";
-    motor.setMode(DcMotor.RunMode.RUN_WITH_ENCODEER);
+    //encoder = "Mother";
+    //motor.setMode(DcMotor.RunMode.RUN_WITH_ENCODEER);
 
     motor.setDirection(DcMotor.Direction.FORWARD);
     // Wait for the game to start (driver presses PLAY)


### PR DESCRIPTION
- Remove ability for codriver to enable snail mode or affect driving the robot
- Fix build break from temp encoder code
- Update grab rotation to allow rotation every 0.25s
- Add telemetry when TTRobot sleeps and blocks everything else from working
- Add telemetry to DirectControl to measure how long the game loop takes, as sometimes it'll take 2.5s, blocking new input and continuing last input for that long (possibly breaking robot if lift or slide is driven beyond the stops).